### PR TITLE
Allow to set image attributes by chunk options

### DIFF
--- a/_extensions/quarto-ext/lightbox/lightbox.lua
+++ b/_extensions/quarto-ext/lightbox/lightbox.lua
@@ -61,8 +61,12 @@ return {
         meta = quarto.json.decode(div.attributes["lightbox"])
         div = div:walk({
           Image = function(imgEl)
-            for _, v in ipairs(kForwardedAttr) do
-              imgEl.attr.attributes[v] = meta[v] or imgEl.attr.attributes[v]
+            if meta[kNoLightboxClass] then
+              imgEl.classes:insert(kNoLightboxClass)
+            else
+              for _, v in ipairs(kForwardedAttr) do
+                imgEl.attr.attributes[v] = meta[v] or imgEl.attr.attributes[v]
+              end
             end
             return imgEl
           end

--- a/_extensions/quarto-ext/lightbox/lightbox.lua
+++ b/_extensions/quarto-ext/lightbox/lightbox.lua
@@ -55,16 +55,17 @@ return {
           imagesWithinLinks[#imagesWithinLinks + 1] = imageEl
         end
       })
-    end,
+    end
+  },{
     Div = function(div)
       if div.classes:includes("cell") and div.attributes["lightbox"] ~= nil then
         meta = quarto.json.decode(div.attributes["lightbox"])
         div = div:walk({
           Image = function(imgEl)
-            if meta == false or meta[kNoLightboxClass] == true or meta[kLightboxClass] == false then
+            if meta == false or meta[kNoLightboxClass] == true then
               imgEl.classes:insert(kNoLightboxClass)
             else
-              if meta[kLightboxClass] == true then 
+              if not auto and meta and not meta[kNoLightboxClass] then
                 imgEl.classes:insert(kLightboxClass)
               end
               if meta.group then

--- a/_extensions/quarto-ext/lightbox/lightbox.lua
+++ b/_extensions/quarto-ext/lightbox/lightbox.lua
@@ -57,11 +57,11 @@ return {
       })
     end,
     Div = function(div)
-      if div.classes:includes("cell") and div.attributes["lightbox"] then
+      if div.classes:includes("cell") and div.attributes["lightbox"] ~= nil then
         meta = quarto.json.decode(div.attributes["lightbox"])
         div = div:walk({
           Image = function(imgEl)
-            if meta[kNoLightboxClass] == true or meta[kLightboxClass] == false then
+            if meta == false or meta[kNoLightboxClass] == true or meta[kLightboxClass] == false then
               imgEl.classes:insert(kNoLightboxClass)
             else
               if meta[kLightboxClass] == true then 

--- a/_extensions/quarto-ext/lightbox/lightbox.lua
+++ b/_extensions/quarto-ext/lightbox/lightbox.lua
@@ -67,6 +67,9 @@ return {
               if meta[kLightboxClass] == true then 
                 imgEl.classes:insert(kLightboxClass)
               end
+              if meta.group then
+                imgEl.attr.attributes.group = meta.group or imgEl.attr.attributes.group
+              end
               for _, v in ipairs(kForwardedAttr) do
                 imgEl.attr.attributes[v] = meta[v] or imgEl.attr.attributes[v]
               end

--- a/_extensions/quarto-ext/lightbox/lightbox.lua
+++ b/_extensions/quarto-ext/lightbox/lightbox.lua
@@ -55,6 +55,21 @@ return {
           imagesWithinLinks[#imagesWithinLinks + 1] = imageEl
         end
       })
+    end,
+    Div = function(div)
+      if div.classes:includes("cell") and div.attributes["lightbox"] then
+        meta = quarto.json.decode(div.attributes["lightbox"])
+        div = div:walk({
+          Image = function(imgEl)
+            for _, v in ipairs(kForwardedAttr) do
+              imgEl.attr.attributes[v] = meta[v] or imgEl.attr.attributes[v]
+            end
+            return imgEl
+          end
+        })
+        div.attributes["lightbox"] = nil
+      end
+      return div
     end
   },
   {

--- a/_extensions/quarto-ext/lightbox/lightbox.lua
+++ b/_extensions/quarto-ext/lightbox/lightbox.lua
@@ -64,10 +64,6 @@ return {
         div = div:walk({
           Image = function(imgEl)
             imgCount = imgCount + 1
-            if (imgCount > 1 ) then
-              quarto.log.warning("Only one image per chunk is supported with lightbox configuration in chunk.")
-              return nil
-            end
             if meta == false or meta[kNoLightboxClass] == true then
               imgEl.classes:insert(kNoLightboxClass)
             else
@@ -77,8 +73,19 @@ return {
               if meta.group then
                 imgEl.attr.attributes.group = meta.group or imgEl.attr.attributes.group
               end
-              for _, v in ipairs(kForwardedAttr) do
-                imgEl.attr.attributes[v] = meta[v] or imgEl.attr.attributes[v]
+              for _, v in next, kForwardedAttr do
+                if type(meta[v]) == "table" and #meta[v] > 1 then 
+                  -- if list attributes it should be one per plot
+                  if imgCount > #meta[v] then
+                    quarto.log.warning("More plots than '" .. v .. "' passed in YAML chunk options.")
+                  else
+                    attrLb = meta[v][imgCount]
+                  end
+                else 
+                  -- Otherwise reuse the single attributes
+                  attrLb = meta[v]
+                end
+                imgEl.attr.attributes[v] = attrLb or imgEl.attr.attributes[v]
               end
             end
             return imgEl

--- a/_extensions/quarto-ext/lightbox/lightbox.lua
+++ b/_extensions/quarto-ext/lightbox/lightbox.lua
@@ -60,8 +60,14 @@ return {
     Div = function(div)
       if div.classes:includes("cell") and div.attributes["lightbox"] ~= nil then
         meta = quarto.json.decode(div.attributes["lightbox"])
+        local imgCount=0
         div = div:walk({
           Image = function(imgEl)
+            imgCount = imgCount + 1
+            if (imgCount > 1 ) then
+              quarto.log.warning("Only one image per chunk is supported with lightbox configuration in chunk.")
+              return nil
+            end
             if meta == false or meta[kNoLightboxClass] == true then
               imgEl.classes:insert(kNoLightboxClass)
             else

--- a/_extensions/quarto-ext/lightbox/lightbox.lua
+++ b/_extensions/quarto-ext/lightbox/lightbox.lua
@@ -61,9 +61,12 @@ return {
         meta = quarto.json.decode(div.attributes["lightbox"])
         div = div:walk({
           Image = function(imgEl)
-            if meta[kNoLightboxClass] then
+            if meta[kNoLightboxClass] == true or meta[kLightboxClass] == false then
               imgEl.classes:insert(kNoLightboxClass)
             else
+              if meta[kLightboxClass] == true then 
+                imgEl.classes:insert(kLightboxClass)
+              end
               for _, v in ipairs(kForwardedAttr) do
                 imgEl.attr.attributes[v] = meta[v] or imgEl.attr.attributes[v]
               end

--- a/example.qmd
+++ b/example.qmd
@@ -3,6 +3,7 @@ title: Example Lightbox Document
 filters:
   - lightbox
 lightbox: auto
+keep-md: true
 ---
 
 ## Chilmark
@@ -32,6 +33,34 @@ description="Oak Bluffs is famous for its Gingerbread cottages, busy town center
 ![Vineyard lighthouse](images/mv-2.jpg){group="elsewhere"
 description="The Edgartown Lighthouse is a short walk from downtown and has beautiful views over the entrance to Edgartown Harbor."}
 :::
+
+## Code chunks
+
+Options for lightbox can be passed using chunk options (Limitation to one image per chunk for now.)
+
+```{r}
+#| fig-cap: R plot
+#| lightbox:
+#|   group: r-graph
+#|   description: This is 1 to 10 plot
+plot(1:10, rnorm(10))
+```
+
+```{r}
+#| fig-cap: cars
+#| lightbox:
+#|   group: r-graph
+#|   description: We see our cars data above
+plot(cars)
+```
+
+Don't apply lightbox on this last plot, when `lightbox: auto` in main YAML config
+
+```{r}
+#| fig-cap: mtcars
+#| lightbox: false
+plot(mtcars)
+```
 
 ## Credits
 

--- a/example.qmd
+++ b/example.qmd
@@ -34,12 +34,12 @@ description="Oak Bluffs is famous for its Gingerbread cottages, busy town center
 description="The Edgartown Lighthouse is a short walk from downtown and has beautiful views over the entrance to Edgartown Harbor."}
 :::
 
-## Code chunks
+## With computation code chunks
 
-Options for lightbox can be passed using chunk options (Limitation to one image per chunk for now.)
+Options for lightbox can be passed using chunk options.
 
 ```{r}
-#| fig-cap: R plot
+#| fig-cap: Simple demo R plot 
 #| lightbox:
 #|   group: r-graph
 #|   description: This is 1 to 10 plot
@@ -47,14 +47,28 @@ plot(1:10, rnorm(10))
 ```
 
 ```{r}
-#| fig-cap: cars
+#| fig-cap: Plot about cars data
 #| lightbox:
 #|   group: r-graph
 #|   description: We see our cars data above
 plot(cars)
 ```
 
-Don't apply lightbox on this last plot, when `lightbox: auto` in main YAML config
+It is possible to create several plots, and group them in a lightbox gallery. Use list in YAML for options when you have several plots, on per plot.
+```{r}
+#| fig-cap: 
+#|   - Caption for first plot
+#|   - Caption for second plot
+#| lightbox: 
+#|   group: cars
+#|   description: 
+#|     - This is the decription for first graph
+#|     - This is the decription for second graph
+plot(mtcars)
+plot(cars)
+```
+
+When `lightbox: auto` in main YAML config, you can opt-out lightbox on a plot by setting `lightbox: false`
 
 ```{r}
 #| fig-cap: mtcars


### PR DESCRIPTION
This is a proof of concept of how we can use chunk option to configure lightbox individually for plots. 

Basically, we leverage the fact that we pass chunk option untouched and encoded to JSON to our `.cell` div. 

Here I am proposing this syntax
````
```{r}
#| fig-cap: R plot
#| lightbox:
#|   group: r-plot
#|   description: This description is never shown
plot(1:10, rnorm(10))
```
````

so that we get chunk options namespaced by extension. 

The filter is quite simple: 

* After reading the Meta, we process the Div of class `cell` which have an attribute `lightbox` sets.
* Options are processed to either set classes or attributes in images inside the Div. 
* The rest of the filter will apply on the images that have the attributes and class correctly set by computation chunk

Currently for this POC I did not dealt with several images per chunk and added a warning. We can probably do the same; 

What do you think @dragonstyle ? 